### PR TITLE
Use local_inner_macros to make compatible with new-style macro imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "if_chain"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Chris Wong <lambda.fairy@gmail.com>"]
 
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 /// Macro for writing nested `if let` expressions.
 ///
 /// See the crate documentation for information on how to use this macro.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! if_chain {
     ($($tt:tt)*) => {
         __if_chain! { @init () $($tt)* }
@@ -136,7 +136,7 @@ macro_rules! if_chain {
 }
 
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! __if_chain {
     (@init ($($tt:tt)*) then $then:block else $other:block) => {
         __if_chain! { @expand $other $($tt)* then $then }


### PR DESCRIPTION
See https://github.com/rust-lang-nursery/lazy-static.rs/commit/e3b8efe2196125e2b94c41a690c551163a2ddc85