### PR TITLE
Fix expanding to short versions of constructs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 rust:
   - beta
   - stable
-  - 1.11.0
+  - 1.12.0
 script:
   - cargo test


### PR DESCRIPTION
This PR fixes 2 issues:

* The documentation shows that `if_chain` expands `let` and `if let` to equivalent Rust expressions, but that's not the case on latest master --- both expand to `match` expressions. This can be surprising when using macro expansion tools (e.g. `cargo expand`) and the result doesn't look like what one would expect after reading docs.
  Special handling for some cases should make the result clearer for users and potentially reduce burden placed on the optimizer, even if by a very small margin. 
* Block matchers (or any AST node matchers in general) and verbatim code interact poorly: after `{}` is matched with a block matcher, it can't be matched with literal `{}` anymore. When that happens in a certain recursion step, for all next recursion steps the macro match arm with `{}` becomes unreachable and the code gets expanded to `if { ... } else { {} }`. 
  The fix is to not use block matchers in presence of verbatim matching code. Generic `tt` matchers should be used in this case.

Example that exhibits both problems:

```rust
if_chain! {
   if let Some(y) = x;
   if y.len() == 2;
   if let Some(z) = y.first();
   then {
       do_stuff_with(*z);
   }
}
```

Expansion before this PR:

```rust
match x {
    Some(y) => {
        if y.len() == 2 {
            match y.first() {
                Some(z) => {
                    do_stuff_with(*z);
                }
                _ => {}
            }
        } else {
            {}
        }
    }
    _ => {}
}
```

Expansion after this PR:

```rust
if let Some(y) = x {
    if y.len() == 2 {
        if let Some(z) = y.first() {
            do_stuff_with(*z);
        }
    }
}
```

I think `if_chain` should have macro expansion tests, but I don't know how to set up something like that (`compiletest_rs` seems to not support that case).