### PR TITLE
Fix scope of else clause, and avoid duplication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,10 @@ macro_rules! __if_chain {
 
 #[cfg(test)]
 mod tests {
+    #[derive(Debug,Copy,Clone,Eq,PartialEq)]
+    enum Got { Then(usize), Else(usize) }
+    use self::Got::*;
+
     #[test]
     fn simple() {
         let x: Option<Result<Option<String>, (u32, u32)>> = Some(Err((41, 42)));
@@ -310,5 +314,24 @@ mod tests {
             else { x += 1; }
         };
         assert_eq!(x, 3);
+    }
+
+    #[test]
+    fn weirdness() {
+        fn wat(seq: &[usize]) -> Got {
+            let mut seq = seq.iter().copied();
+            let dunno  = 0;
+            if_chain! {
+                if let Some(dunno) = seq.next();
+                if let Some(dunno) = seq.next();
+                then { Then(dunno) }
+                else { Else(dunno) }
+            }
+        }
+
+        assert_eq!(Else(0), wat(&[         ]));
+        assert_eq!(Else(1), wat(&[ 1       ]));
+        assert_eq!(Then(2), wat(&[ 1, 2    ]));
+        assert_eq!(Then(2), wat(&[ 1, 2, 3 ]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,4 +338,17 @@ mod tests {
         assert_eq!(Then(2), wat(&[ 1, 2    ]));
         assert_eq!(Then(2), wat(&[ 1, 2, 3 ]));
     }
+
+    #[test]
+    fn let_rebinding() {
+        let v = Some(Some(Some('a')));
+        if_chain! {
+            if let Some(v) = v;
+            if let Some(v) = v;
+            if let Some(v) = v;
+            if true;
+            then { let _: char = v; }
+            else { let _: Option<Option<Option<char>>> = v; }
+        };
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,11 +323,11 @@ mod tests {
     fn let_rebinding_values() {
         #[allow(unused_variables)]
         fn wat(seq: &[usize]) -> Got {
-            let mut seq = seq.iter().copied();
+            let mut seq = seq.iter();
             let dunno  = 0;
             if_chain! {
-                if let Some(dunno) = seq.next(); // unused binding
-                if let Some(dunno) = seq.next();
+                if let Some(&dunno) = seq.next(); // unused binding
+                if let Some(&dunno) = seq.next();
                 then { Then(dunno) }
                 else { Else(dunno) }
             }


### PR DESCRIPTION
Hi.  I really like this macro.  I'm using it heavily.  Rust needs lots of early return constructs (Maybe/Error monad, if you like to think of things that way) and this one composes nicely with `?` :-).

I'm in the habit of rebinding the same variable name as I go through processing it.  This works great in Rust.  But there is a problem with`if_chain!`.  Because the `else` clause is duplicated into the `else` of each nested `if`, it gets the wrong variable scope: bindings from earlier `if let...;` clauses are visible to each copy of the `else`.

Different copies of the else clause see different variable bindings!  Usually these bindings have different types, so the result doesn't compile.  See my new test case `let_rebinding`, which progressively unwraps; that does not compile without my substantive change.

But if the `else` clause is generic enough or uses `into` or the rebindings are different values rather than different types, the code can compile and produce (almost certainly) wrong answers.

The fix to this is to have only one copy of the `else` clause.  This can be achieved by threading the return value of the `then` through as a `Some`, and unwrapping that and substituting the `else` for `None` at the end.

### Intended effect of this change

For your edification and/or amusement I wrote a test case that compiles both before and after, and produces different results.  This section of the diff demonstrates it:

https://github.com/ijackson/if_chain/commit/47fac8861431cda12d6ea313bd4d03698f92dcd3#r48559776

After this change:
 * The `else` always sees the original binding of `dunno`, ie, zero.
 * The first `if let Some(dunno) ...;` rebinding is not used, as indeed the code layout would seem to suggest.

### Undesirable side-effect, and possible alternatives

I have discovered that indirecting the return value through a `Some` in this way breaks some autoderef that otherwise occurs.  So this can break existing code with new type errors.  The fix is simple - the sprinkling of new `*` (in the `then` clause).  That makes this a clear semver break.

A possible alternative would be to try to use `loop`.  That can provide nonlocal exits.  However, `loop` cannot be used as a general facility for building this kind of thing  mostly because `break ()` is not legal in a `for` loop, which means that it is not possible to rethrow an inner `break`.  [RFC2046](https://github.com/rust-lang/rfcs/pull/2046) looks like it would help  but wouldn't because it forbids inner `break`s.

*Edited:* Previously I discussed whether this was a breaking change under the assumption that the only effect on code which compiles today is the intended semantic change.  However given this type problem this is a breaking change.

### Example from my own code

```
+  let piece: Option<PieceId> = some_datastructure.get(vis)
+  let piece: Option<PieceId> = if_chain! {
+    if let Some(piece) = piece;
+    if let Some(gpc) = gs.pieces.get(piece);
+    if ... [ much elided ];
+    then { None }
+    else { piece }
+  };
```

In my actual code I have to write `if let Some(p) = piece;` so that I don't rebind `piece`.

You may think the above is poor style :-), but there are other similar situations.  Anything where any of the `if ...;` rebinds a variable from the environment which is used in the `else`.