### PR TITLE
Extra tests for move and autoderef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,4 +325,22 @@ mod tests {
         }
         f("foo");
     }
+
+    #[test]
+    fn no_move() {
+        struct NoCopy;
+        let new_record = NoCopy;
+        let mut store = None;
+        let returned = if_chain!{
+            if true;
+            then {
+                store = Some(new_record);
+                None
+            } else {
+                Some(new_record)
+            }
+        };
+        drop(returned);
+        drop(store);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,4 +311,18 @@ mod tests {
         };
         assert_eq!(x, 3);
     }
+
+    #[test]
+    fn magic_deref() {
+        fn f(y: &'static str) -> (&'static str, bool) {
+            let b: [&str; 1] = ["a"];
+            if_chain! {
+                if false;
+                if let Some(x) = b.get(1);
+                then { (x, true) }
+                else { (y, false) }
+            }
+        }
+        f("foo");
+    }
 }


### PR DESCRIPTION
My now-closed-by-me MR #14 seemed simple and passed the in-tree `if_chain` tests but produced a number of regressions in projects of my own.  That seems suboptimal.  I have distilled the failure cases into these new tests, which pass on current `if_chain` and break with my #14.