### PR TITLE
fix for OR_PATTERNS_BACK_COMPAT lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ macro_rules! __if_chain {
         }
     };
     // `let` with multiple patterns
-    (@expand { $($other:tt)* } let $pat1:pat | $($pat:pat)|+ = $expr:expr; $($tt:tt)+) => {
+    (@expand { $($other:tt)* } let $pat1:pat_param | $($pat:pat_param)|+ = $expr:expr; $($tt:tt)+) => {
         match $expr {
             $pat1 | $($pat)|+ => __if_chain! { @expand { $($other)* } $($tt)+ }
         }
@@ -211,7 +211,7 @@ macro_rules! __if_chain {
         }
     };
     // `if let` with multiple matterns and a fallback (if present)
-    (@expand { $($other:tt)* } if let $pat1:pat | $($pat:pat)|+ = $expr:expr; $($tt:tt)+) => {
+    (@expand { $($other:tt)* } if let $pat1:pat_param | $($pat:pat_param)|+ = $expr:expr; $($tt:tt)+) => {
         match $expr {
             $pat1 | $($pat)|+ => { __if_chain! { @expand { $($other)* } $($tt)+ } },
             _ => { $($other)* }


### PR DESCRIPTION
This is preparation for Rust 2021, which changes the meaning of `pat`. In 2021 edition it will be possible to skip the or-alternation and `pat_param` and just use `pat` directly, but the present code using `$pat1:pat | $($pat:pat)|+` will break in 2021 edition.