### PR TITLE
Add braces around "let with multiple patterns" case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ macro_rules! __if_chain {
     // `let` with multiple patterns
     (@expand { $($other:tt)* } let $pat1:pat | $($pat:pat)|+ = $expr:expr; $($tt:tt)+) => {
         match $expr {
-            $pat1 | $($pat)|+ => __if_chain! { @expand { $($other)* } $($tt)+ }
+            $pat1 | $($pat)|+ => { __if_chain! { @expand { $($other)* } $($tt)+ } }
         }
     };
     // `if let` with a single pattern
@@ -308,7 +308,7 @@ mod tests {
 
             then { x += y; }
             else { x += 1; }
-        };
+        }
         assert_eq!(x, 3);
     }
 }


### PR DESCRIPTION
This fixes the trailing semicolon warning:

```
warning: trailing semicolon in macro used in expression position
   --> src/lib.rs:297:37
    |
297 |             then { assert_eq!(x, 42); }
    |                                     ^
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
```

It is also consistent with the "if let with multiple patterns" case, which wraps the body in braces already.